### PR TITLE
Don't call stls in popStore when tls is disabled

### DIFF
--- a/lib/popStore.js
+++ b/lib/popStore.js
@@ -29,11 +29,7 @@ PopStore.prototype.connect = function(callback) {
       return callback(err);
     }
     this.status = STATE.CONNECTED;
-    self.POP3Client.stls(function(err, rawdata){
-      if (err) {
-        self.POP3Client.quit();
-        return callback(err);
-      }
+    var login = function() {
       self.POP3Client.login(self.login, self.password, function(err,rawdata){
           if (err) {
             self.POP3Client.quit();
@@ -42,7 +38,21 @@ PopStore.prototype.connect = function(callback) {
           self.status = STATE.LOGGED_IN;
           callback(null, rawdata);
         });
-    });
+    }
+
+    if(self.tls) {
+      self.POP3Client.stls(function(err, rawdata){
+        if (err) {
+          self.POP3Client.quit();
+          return callback(err);
+        }
+        
+        login();
+      });
+    }
+    else {
+      login();
+    }
   });
 };
 


### PR DESCRIPTION
Connecting to a POP3 mailserver without TLS fails. In the popStore.js at line 32 the stls function is called even if enabletls is false. This throws an stls error which causes the client to quit.

This change calls stls only when tls is enabled. When tls is disabled, the client immediatly authenticates.

PS Great library!
