### PR TITLE
Null check on socket

### DIFF
--- a/lib/poplib.js
+++ b/lib/poplib.js
@@ -100,9 +100,11 @@ function POP3Client(port, host, options) {
     var checkResp = true;
     var err = null;
     var detach = function() {
+     if (socket !== null) {
       socket.removeAllListeners("data");
       socket.removeAllListeners("error");
       socket.removeAllListeners("close");
+     }
     };
 
     socket.on("data", function(data) {


### PR DESCRIPTION
Receiving error:
> TypeError: Cannot read property 'removeAllListeners' of null

Root Cause:
socket.on("close") is raised after failing to login. Detach is called but socket is null.

Remediation:
check if socket is not null before removing listeners